### PR TITLE
appstream: add patch so that appdata validates

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
-    "skip-appstream-check": true,
     "skip-arches": [
         "arm",
         "i386"

--- a/org.musescore.MuseScore.yaml
+++ b/org.musescore.MuseScore.yaml
@@ -114,3 +114,5 @@ modules:
           - echo '492d7ef' > mscore/revision.h
       - type: patch
         path: patches/musescore-mime-use-appid-icons.patch
+      - type: patch
+        path: patches/musescore-appdata.diff

--- a/patches/musescore-appdata.diff
+++ b/patches/musescore-appdata.diff
@@ -1,0 +1,78 @@
+diff --git a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
+index ddc66dbbe..17304cb75 100644
+--- a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
++++ b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
+@@ -82,6 +82,56 @@
+     <content_attribute id="money-purchasing">mild</content_attribute>
+   </content_rating>
+   <releases>
++    <release date="2019-11-14" version="3.3.2">
++      <url>https://musescore.org/en/3.3.2</url>
++      <description>
++        <p>Fixes</p>
++        <ul>
++          <li>"Save online" failed in some cases</li>
++          <li>Palettes were incorrectly placed when using multiple HighDPI monitors and scaling</li>
++          <li>Palettes disappeared on Ubuntu 18.04 in some cases</li>
++        </ul>
++      </description>
++    </release>
++    <release date="2019-11-13" version="3.3.1">
++      <url>https://musescore.org/en/3.3.1</url>
++    </release>
++    <release date="2019-10-31" version="3.3">
++      <url>https://musescore.org/en/3.3</url>
++      <description>
++        <p>New:</p>
++        <ul>
++          <li>Complete palettes redesign</li>
++          <li>Note Input workflow improvements</li>
++          <li>Native support for Roman numeral analysis and Nashville notation</li>
++        </ul>
++        <p>Improvements:</p>
++        <ul>
++          <li>Chord Symbol Formatting not only for MuseJazz has been supported</li>
++          <li>Symbols can be attached to barlines</li>
++          <li>Multiple improvements to the Plugin API</li>
++          <li>Implement changing palette and palette cell properties on fly</li>
++          <li>Current workspace is automatically saved on each action that changes the workspace</li>
++          <li>Palettes and workspaces can be reset to the default state defined by the workspace you started customisations from</li>
++          <li>Improve algorithm for determining start point for note input</li>
++          <li>Move the viewport to show actual changes in the score if they are outside of the current view</li>
++        </ul>
++        <p>Fixes:</p>
++        <ul>
++          <li>
++            <li>NVDA screen reader didn't work</li>
++            <li>Various MusicXML Import/Export fixes</li>
++            <li>Various fixes for the playback of tied notes, muted voices and notes being edited in parts</li>
++            <li>Sticking was not linked between score and parts</li>
++            <li>The presence of fretboard diagrams prevented input of chord symbols in other staves</li>
++            <li>Loop playback was set incorrectly in parts</li>
++            <li>Shortcuts navigation across the palettes was broken</li>
++            <li>Palettes and palette cells were not translated</li>
++            <li>It was impossible to enter successive sticking elements</li>
++          </li>
++        </ul>
++      </description>
++    </release>
+     <release date="2019-07-08" version="3.2.3">
+       <description>
+         <p>This release fixes some issues with tuplets and fingering layout, MDL Articulations, plugins, and Score_and_Parts PDFs on the Macintosh.</p>
+@@ -93,6 +143,7 @@
+       </description>
+     </release>
+     <release date="2019-06-28" version="3.2.1">
++      <url>https://musescore.org/en/3.2.1</url>
+       <description>
+         <p>This release fixes some bugs and crashes, especially wrt. unsaved Sticking and articulations placement.</p>
+       </description>
+@@ -311,7 +362,7 @@
+         <ul>
+           <li>Fix #270496: Add missing elements to incomplete tuplets when reading from a file</li>
+           <li>Fix #272042: Saved preferences override command line options</li>
+-          <li>Debian fix: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898757. Fix crash when starting with piano open.</li>
++          <li>Debian bug 898757. Fix crash when starting with piano open.</li>
+           <li>Allow path to be relative to stored album file</li>
+           <li>Fix #273660 : MIDI Keyboard Not Responded when Pressed Before Opening a Score</li>
+         </ul>


### PR DESCRIPTION
This should make flathub display the right version.

Fixes #44