### PR TITLE
Issue #39 - Update SDK/runtime to 5.14

### DIFF
--- a/org.musescore.MuseScore.yaml
+++ b/org.musescore.MuseScore.yaml
@@ -1,11 +1,11 @@
 ---
 app-id: org.musescore.MuseScore
 
-base: io.qt.qtwebkit.BaseApp
-base-version: '5.12'
+base: io.qt.qtwebengine.BaseApp
+base-version: '5.14'
 
 runtime: org.kde.Platform
-runtime-version: '5.12'
+runtime-version: '5.14'
 sdk: org.kde.Sdk
 
 command: mscore
@@ -136,3 +136,5 @@ modules:
         path: patches/musescore-mime-use-appid-icons.patch
       - type: patch
         path: patches/musescore-appdata.diff
+      - type: patch
+        path: patches/musescore-webengine.diff

--- a/patches/musescore-webengine.diff
+++ b/patches/musescore-webengine.diff
@@ -2,7 +2,7 @@ diff --git a/main/CMakeLists.txt b/main/CMakeLists.txt
 index 6c489e86c..66bddcf01 100644
 --- a/main/CMakeLists.txt
 +++ b/main/CMakeLists.txt
-@@ -218,20 +218,20 @@ else (MINGW)
+@@ -218,20 +218,6 @@ else (MINGW)
  
     if ( NOT MSVC )
        ## install qwebengine core
@@ -20,20 +20,6 @@ index 6c489e86c..66bddcf01 100644
 -            DESTINATION lib/qt5/translations
 -            )
 -      endif(NOT APPLE AND USE_WEBENGINE)
-+##      if (NOT APPLE AND USE_WEBENGINE)
-+##         install(PROGRAMS
-+##            ${QT_INSTALL_LIBEXECS}/QtWebEngineProcess
-+##            DESTINATION bin
-+##            )
-+##         install(DIRECTORY
-+##            ${QT_INSTALL_DATA}/resources
-+##            DESTINATION lib/qt5
-+##            )
-+##         install(DIRECTORY
-+##            ${QT_INSTALL_TRANSLATIONS}/qtwebengine_locales
-+##            DESTINATION lib/qt5/translations
-+##            )
-+##      endif(NOT APPLE AND USE_WEBENGINE)
  
        set_target_properties (
           mscore

--- a/patches/musescore-webengine.diff
+++ b/patches/musescore-webengine.diff
@@ -1,0 +1,39 @@
+diff --git a/main/CMakeLists.txt b/main/CMakeLists.txt
+index 6c489e86c..66bddcf01 100644
+--- a/main/CMakeLists.txt
++++ b/main/CMakeLists.txt
+@@ -218,20 +218,20 @@ else (MINGW)
+ 
+    if ( NOT MSVC )
+       ## install qwebengine core
+-      if (NOT APPLE AND USE_WEBENGINE)
+-         install(PROGRAMS
+-            ${QT_INSTALL_LIBEXECS}/QtWebEngineProcess
+-            DESTINATION bin
+-            )
+-         install(DIRECTORY
+-            ${QT_INSTALL_DATA}/resources
+-            DESTINATION lib/qt5
+-            )
+-         install(DIRECTORY
+-            ${QT_INSTALL_TRANSLATIONS}/qtwebengine_locales
+-            DESTINATION lib/qt5/translations
+-            )
+-      endif(NOT APPLE AND USE_WEBENGINE)
++##      if (NOT APPLE AND USE_WEBENGINE)
++##         install(PROGRAMS
++##            ${QT_INSTALL_LIBEXECS}/QtWebEngineProcess
++##            DESTINATION bin
++##            )
++##         install(DIRECTORY
++##            ${QT_INSTALL_DATA}/resources
++##            DESTINATION lib/qt5
++##            )
++##         install(DIRECTORY
++##            ${QT_INSTALL_TRANSLATIONS}/qtwebengine_locales
++##            DESTINATION lib/qt5/translations
++##            )
++##      endif(NOT APPLE AND USE_WEBENGINE)
+ 
+       set_target_properties (
+          mscore


### PR DESCRIPTION
- This update the SDK for `stable` to KDE 5.14

(Closes #39 - albeit that requests 5.13)
(Closes #40 - obsoleted)