### PR TITLE
Use the KDE 5.15 runtime

### DIFF
--- a/org.musescore.MuseScore.yaml
+++ b/org.musescore.MuseScore.yaml
@@ -2,10 +2,10 @@
 app-id: org.musescore.MuseScore
 
 base: io.qt.qtwebengine.BaseApp
-base-version: '5.14'
+base-version: '5.15'
 
 runtime: org.kde.Platform
-runtime-version: '5.14'
+runtime-version: '5.15'
 sdk: org.kde.Sdk
 
 command: mscore


### PR DESCRIPTION
- This closes #42 - tooltips now work

I didn't change anything with Jack support yet.