### PR TITLE
Allow org.freedesktop.UPower access

### DIFF
--- a/org.musescore.MuseScore.yaml
+++ b/org.musescore.MuseScore.yaml
@@ -33,6 +33,8 @@ finish-args:
   # JACK
   - --filesystem=xdg-run/pipewire-0
   - --system-talk-name=org.freedesktop.RealtimeKit1
+  # Allow UPower access 
+  - --system-talk-name=org.freedesktop.UPower
 
 cleanup-commands:
   # Cleanup after QtWebKit


### PR DESCRIPTION
Fix the errors: 
- Failed to call method: org.freedesktop.DBus.Properties.Get
- Failed to call method: org.freedesktop.UPower.GetDisplayDevice
- Failed to call method: org.freedesktop.UPower.EnumerateDevices