### PR TITLE
[beta] MuseScore 4.0 beta

### DIFF
--- a/org.musescore.MuseScore.yaml
+++ b/org.musescore.MuseScore.yaml
@@ -2,23 +2,23 @@
 app-id: org.musescore.MuseScore
 
 base: io.qt.qtwebengine.BaseApp
-base-version: '5.15-21.08'
+base-version: '5.15-22.08'
 
 runtime: org.kde.Platform
-runtime-version: '5.15-21.08'
+runtime-version: '5.15-22.08'
 sdk: org.kde.Sdk
 
 command: mscore
-rename-desktop-file: mscore.desktop
 rename-icon: mscore
+copy-icon: true
 desktop-file-name-prefix: "(beta) "
 
 finish-args:
   # X11 + XShm access
   - --share=ipc
   - --socket=x11
-  # Enable Wayland but keep X11 default for now
-  - --socket=wayland
+  # Too many wayland bugs.
+  # --socket=wayland
   - --env=QT_QPA_PLATFORM=xcb
   # MuseScore.com connectivity
   - --share=network
@@ -40,7 +40,7 @@ finish-args:
 add-extensions:
   org.freedesktop.LinuxAudio.Plugins:
     directory: extensions/Plugins
-    version: '21.08'
+    version: '22.08'
     add-ld-path: lib
     subdirectories: true
     merge-dirs: vst3
@@ -53,7 +53,6 @@ cleanup-commands:
   - rm -rf /app/lib/{cmake,mkspecs,pkgconfig}
 
 modules:
-  - shared-modules/linux-audio/jack2.json
   - name: portmidi
     buildsystem: cmake-ninja
     config-opts:
@@ -86,6 +85,8 @@ modules:
       - -DBUILD_UNIT_TESTS=OFF
       - -DBUILD_VST=ON
       - -DVST3_SDK_PATH=../VST_SDK/vst3sdk
+      # thid is a stupidly pre-compiled binary that doesn't work with openSSL 3
+      - -DBUILD_CRASHPAD_CLIENT=OFF
       - -DMUSESCORE_BUILD_CONFIG=release
     cleanup:
       - /include
@@ -108,8 +109,8 @@ modules:
         done
     sources:
       - type: archive
-        url: https://github.com/musescore/MuseScore/archive/refs/tags/v4.0_alpha_2.tar.gz
-        sha256: 164c3920f7ca80059c0534cb8475b8acf0c86c8ac0536b8d415ef55949fcc64f
+        url: https://github.com/musescore/MuseScore/archive/refs/tags/v4.0_beta.tar.gz
+        sha256: 6f9604905ce644bc540529ef9496d6772c3c8b4936288c3f3056f00ae900aafd
       - type: archive
         url: https://download.steinberg.net/sdk_downloads/vst-sdk_3.7.5_build-44_2022-05-19.zip
         sha256: c671e31e71613d1de4205e9bb2dfe2a7c83582b6c410ee23cdf2fc5bbd600537

--- a/patches/musescore-appdata.diff
+++ b/patches/musescore-appdata.diff
@@ -1,418 +1,49 @@
+From 4da1af6a7ffe6865486951c8ee3919929b8d8606 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hubert=20Figui=C3=A8re?= <hub@figuiere.net>
+Date: Tue, 25 Oct 2022 09:33:39 -0400
+Subject: [PATCH] Validate strict
+
+- remove non-allowed icon
+- also remove duplicate release
+---
+ build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
 diff --git a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
-index d52ce502f..d9237744d 100644
+index 34ece141a540..b4d35335c190 100644
 --- a/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
 +++ b/build/Linux+BSD/org.musescore.MuseScore.appdata.xml.in
-@@ -82,6 +82,413 @@
-     <content_attribute id="money-purchasing">mild</content_attribute>
-   </content_rating>
-   <releases>
-+    <release date="2022-08-09" version="4.0.0_alpha_2" />
-+    <release date="2021-02-08" version="3.6.2">
-+      <url>https://github.com/musescore/MuseScore/releases/tag/v3.6.2</url>
-+      <description>
-+<p>Fixes</p>
-+<ul>
-+<li>Fixed an issue with gap between staff and final barline with courtesy clef</li>
-+<li>Fixed an issue when removing spanners from measures outside of the rewrite range</li>
-+<li>Fixed an accessibility issue with the score migration dialog</li>
-+<li>Fixed a crash related to QtWebEngineProcess after update</li>
-+<li>Fixed an issue with timeline showing part name rather than instrument name</li>
-+<li>Fixed an issue with focus of dockable windows when visibility is toggled</li>
-+<li>Fixed an issue where custom gliss text reverts to default "gliss"</li>
-+<li>Added missing Flügelhorns to instrument ordering definitions</li>
-+<li>Fixed an issue where beams cannot be connected over quarter rests</li>
-+<li>Fixed an issue where staff spacers do not work on last system of page</li>
-+<li>Fixed an issue with broken swapping of notes/chords with Shift + Left/Right</li>
-+<li>Fixed an issue with incomplete import from ScoreScan XML file</li>
-+<li>Fixed an issue with unsaved default settings to pre-3.6 score after 'reset styles to default'</li>
-+<li>Fixed an issue with Banjo fifth string fret numbers</li>
-+<li>Fixed an issue where invisible breath marks impact layout</li>
-+<li>Fixed a crash during the opening of a score with a missing section break</li>
-+<li>Applying tremolo is now a toggle operation</li>
-+<li>Fixed an issue where the Mixer panel is not fully shown when opened</li>
-+<li>Fixed an issue where an empty rehearsal mark is not deleted after entering a system break</li>
-+<li>Fixed an issue where multi-measure rest numbers can collide with other elements</li>
-+<li>Fixed an issue where deleting a breath/caesura leads to the wrong note being selected</li>
-+<li>Fixed an issue when parts inherit non-default style from score</li>
-+<li>Fixed a crash when changing time signature at the beginning of a corrupted measure</li>
-+<li>Fixed an issue with unreadable chord symbols</li>
-+<li>Updated the close icon for Import Midi Panel (and Find/GoTo)</li>
-+<li>Fixed an issue with auto-sizing of vertical frames when dragging the height handle</li>
-+</ul>
-+      </description>
-+    </release>
-+    <release date="2021-01-27" version="3.6.1">
-+      <url>https://github.com/musescore/MuseScore/releases/tag/v3.6.1</url>
-+      <description>
-+<p>Fixes</p>
-+<ul>
-+<li>Fixed a crash on open of a file with start repeat in continuous view</li>
-+<li>Fixed an issue when switching tabs when opening a score while "Score migration dialog" is open</li>
-+<li>Fixed crashes when rearranging instrument positions and changing Ordering</li>
-+<li>Fixed an issue where the window is marked as modified, even when the last score is closed</li>
-+<li>Fixed a crash when opening scores with large orchestration created in older versions of MuseScore</li>
-+<li>Fixed an issue with incorrect order of Violins in Orchestra template</li>
-+<li>Fixed a crash when hiding palettes</li>
-+<li>Fixed an export failure when part name contains a slash</li>
-+<li>Fixed an issue where spacers do not function when vertical justification is enabled</li>
-+<li>Added an option to Copy SMuFL Symbol Code for symbols in Master Palette</li>
-+<li>Clef changes are no longer visible on hidden staves</li>
-+<li>Fixed an issue where first system indentation can cause measures to not fit on system</li>
-+<li>Fixed an issue with wrong key signatures upon "Reset Al Styles" in concert pitch scores</li>
-+<li>Display symbols' SMuFL name in Symbols Palette</li>
-+<li>Removed corner radius from new default rehearsal mark style</li>
-+<li>Fixed an issue where custom style defaults are ignored when creating new score from template</li>
-+<li>Fixed an issue where applying a key change to a selection causes a crash when transposing instruments are involved</li>
-+<li>Fixed an issue where an incomplete voice in local time signature leads to corruption upon import</li>
-+<li>Fixed an issue where swapping notes in a two-note tremolo causes corrupted tremolo, and crash</li>
-+<li>Fixed an issue where two-note tremolos display incorrectly on a stave with custom scale</li>
-+<li>Fixed an issue where measure number offset changes on reload</li>
-+<li>It is now possible to copy/paste the LetRing, PalmMute and Vibrato elements</li>
-+<li>The link on "Score migration dialog" now leads to Bilibili if using Chinese</li>
-+</ul>
-+     </description>
-+    </release>
-+    <release date="2021-01-14" version="3.6">
-+    <description>
-+      <p>New</p>
-+      <ul>
-+        <li>Added the new default notation fonts "Leland"</li>
-+<li>Added the new default text font "Edwin"</li>
-+<li>Added a new dialog that suggests trying out the new engraving defaults</li>
-+<li>Added automatic score ordering and bracketing</li>
-+<li>Added automatic vertical justification of staves</li>
-+<li>Added Mountain Dulcimer instrument and 3-string tab presets</li>
-+<li>Added portamento for FLUID synthesiser</li>
-+<li>Added Petaluma notation font</li>
-+<li>Added mnemonics for "Save", "Save As" and "Resource Manager"</li>
-+</ul>
-+<p>Improvements</p>
-+<ul>
-+<li>Redesigned the score migration dialog and the algorithm for applying new styles</li>
-+<li>Improved the vertical staff justification algorithm</li>
-+<li>First system indentation now takes the maximum of the length of the instruments labels and the style parameter</li>
-+<li>Added a support of measure number interval at multi-measure rests</li>
-+<li>Improved the recognition of instruments when loading a pre-3.6 score</li>
-+<li>Altered default canvas background colour</li>
-+<li>Improved functionality and appearance of 'Add Palettes' button</li>
-+<li>Implemented a new "Export" dialog</li>
-+<li>Improved the score symbols appearance</li>
-+<li>Updated Bravura notation font to version 1.39</li>
-+<li>Extended the set of accidentals</li>
-+<li>Implemented a third stroke style for minim-based two-note tremolos</li>
-+<li>Added extended fermata symbols to MusicXML I/O</li>
-+<li>Updated SMuFL to the latest version 1.3</li>
-+<li>Added support for triple sharp and triple flat</li>
-+<li>Replaced the accidentals from Emmentaler with improved ones from Parnassus</li>
-+<li>Added an indication of sounding pitch if the global concert pitch toggle is off and the current instrument has an actual pitch</li>
-+<li>Added heavy, reverse end and heavy double barlines</li>
-+<li>Added Sicilian translation</li>
-+<li>The Edit Style dialog is no longer modal: the score can now be traversed while the dialog is open</li>
-+<li>Added an alternative choice of “To Coda”</li>
-+<li>Added a harmony duration interpretation</li>
-+<li>MacOS window title bars now update according to the selected theme in MuseScore</li>
-+<li>Added an automatic change of theme in MuseScore according to the MacOS dark/light mode setting</li>
-+<li>The width of accidental symbols in the font is now honoured during drawing</li>
-+<li>Solo instrument names are ending in "solo"</li>
-+<li>Improved a collision avoidance between accidentals and ledger lines</li>
-+<li>Improved an appearance of shadow notes</li>
-+<li>Improved layout of the "Edit Style" dialog</li>
-+<li>Cleaned up all unnecessary spaces and words used in file export</li>
-+<li>Order of buttons in "Score migration" dialog is now platform-specific</li>
-+<li>Improved search behavior in "Palettes"</li>
-+<li>Added an option for applying new text font (Edwin) to imported MusicXML scores</li>
-+<li>Replenished collection of demo scores</li>
-+<li>Improved layout of the "Edit Style" dialog</li>
-+<li>Improved handling of score orders</li>
-+<li>Improved the appearance of ambitus caps</li>
-+<li>Improved the appearance of the score migration dialog</li>
-+</ul>
-+<p>Fixes</p>
-+<ul>
-+<li>Fixed a bug preventing generation of square braces for an instrument with multiple staves.</li>
-+<li>Fixed an issue where style dialog loses setting of chord symbol radio buttons</li>
-+<li>Fixed an issue with measure numbers not showing when first staff is cut away</li>
-+<li>Fixed an issue where ledger lines only showed correctly when staff line spacing set to 0.5 increments (i.e 1.5, 2.0, etc.)</li>
-+<li>Fixed an issue with image resize not correctly honouring aspect ratio</li>
-+<li>Fixed an issue with "Select Similar Beat" command not working with shortened measures</li>
-+<li>Fixed an issue where glissandos collide with double-digit start fretmarks</li>
-+<li>Fixed glissando and portamento playback</li>
-+<li>Enabled selection of text using the mouse in Palettes search field</li>
-+<li>Adjusted the "Range-transpose" shortcuts</li>
-+<li>Adjusted the appearance of dotted lines</li>
-+<li>Staff visibility changes are now allowed mid-score</li>
-+<li>Fixed an issue with the appearance of additive time signatures</li>
-+<li>Fixed an issue where Mandolin unintentionally has a Grand Piano sound</li>
-+<li>Expanded the list of special characters in "Special characters -> Common Symbols"</li>
-+<li>Jump at Volta End no longer skips last measure</li>
-+<li>Fixed a crash when switching instruments from an instrument with tabulature</li>
-+<li>Fixed an issue when toggling between clefs of unpitched and pitched instruments, which led to a crash</li>
-+<li>Fixed an issue where pressing Enter in the Score Properties dialog applies to the "New…" button rather than the "OK" button</li>
-+<li>Fixed a crash when deleting header/footer text after hiding</li>
-+<li>Fixed an issue where removing tuplets after inserting measures caused corruption/crash</li>
-+<li>Reduced useless whitespace in JSON files</li>
-+<li>Disabled auto collision avoidance for rests which do not have auto-placement enabled</li>
-+<li>Fixed an issue where rests cannot be merged together when the measure has 3 or 4 voices</li>
-+<li>Fixed an issue with the "Flatten all Beams" setting being ignored on score reload</li>
-+<li>Fixed an issue where voice-1 rests collide with voice-3 rhythm slashes</li>
-+<li>Fixed an issue where C time signature does not update</li>
-+<li>Fixed an issue with readability of the tempo field by screen readers</li>
-+<li>Fixed a palette search shortcut functionality issue</li>
-+<li>Fixed an issue with missing space between the key signature and the first note when the time signature is hidden</li>
-+<li>Fixed a freeze when a tie has the same start and end note</li>
-+<li>Fixed a crash when deleting or changing a time signature in a multi-measure rest</li>
-+<li>Fixed an issue with import of MusicXML files from the new version of Finale</li>
-+<li>Fixed an incorrect tuplet calculation on a two-note tremolo</li>
-+<li>Removed support for the "place at middle of stem" option for single-note tremolos</li>
-+<li>Fixed an issue where duplication of voltas leads to following voltas being ignored</li>
-+<li>Fixed an issue with MusicXML import of changed transpositions</li>
-+<li>Fixed an issue where hairpin export stops halfway</li>
-+<li>Fixed an issue with FirstSystemIndentation style setting is not taking care lenght instrument labels</li>
-+<li>Fixed an issue when MusicXML import not honored "measure-style/slash"</li>
-+<li>Fixed an issue with application of new styles to 'recent' scores</li>
-+<li>Fixed an issue with application of new styles to pre-3.6 scores</li>
-+<li>Fixed an issue with incorrect brace scaling</li>
-+<li>Fixed an issue with import of MusicXML tempo changes</li>
-+<li>Fixed an issue where aligned pedal lines jump wildly while being dragged</li>
-+<li>Fixed an issue with updating of translations</li>
-+<li>Fixed an issue with export of fretboard diagrams to MusicXML</li>
-+<li>Fixed an issue where atonal key signatures caused spacing issues</li>
-+<li>Fixed an issue with the "Show MIDI controls in mixer" checkbox in "Preferences" dialog</li>
-+<li>Fixed an issue with inconsistent stem directions on middle-line beamed notes</li>
-+<li>Fixed an issue with application of new styles to 'recent' scores</li>
-+<li>Fixed an issue with measure numbers colliding with brackets</li>
-+<li>Fixed an issue with triggering of translation process after a language switch</li>
-+<li>Fixed an issue where fingering was wrongly scaled with note size</li>
-+<li>Fixed an issue with cutaway courtesy clefs not showing</li>
-+<li>Fixed an issue with export of 32nd-note tuplets into MusicXML format</li>
-+<li>Removed unnecessary rounding of BPM value in "Play panel"</li>
-+<li>Fixed an issue with unexpected behavior of "Esc" key in "Edit Style" dialog</li>
-+<li>Fixed a crash when importing a file with an incomplete tuplet</li>
-+<li>Fixed an issue where adding instruments on top of others whose parts have been created leads to score corruption</li>
-+<li>Fixed an issue with styles in the "converter" mode</li>
-+<li>Fixed an issue where changing any property on a text line resets all styled properties to default</li>
-+<li>Fixed an issue where the "Custom" string in "Instrument &gt; Order" shows untranslated</li>
-+</ul>
-+</description>
-+    </release>
-+    <release date="2020-10-16" version="3.5.2">
-+      <url>https://github.com/musescore/MuseScore/releases/tag/v3.5.2</url>
-+      <description>
-+        <p>Fixes</p>
-+        <ul>
-+          <li>Fixed an unexpected page stretching in "Edit style" dialog</li>
-+          <li>Fixed an issue with audio export on Windows, previously exporting to .FLAC or .OGG could result in an empty file that cannot be played</li>
-+          <li>Fixed an issue of harmony playback preferences. Previously, the real value of "Chord symbol playback" was not taken into account until the first toggle of this setting</li>
-+          <li>Fixed a potential crash that could occur when resizing the Piano Roll</li>
-+        </ul>
-+      </description>
-+    </release>
-+    <release date="2020-10-06" version="3.5.1">
-+      <url>https://github.com/musescore/MuseScore/releases/tag/v3.5.1</url>
-+      <description>
-+       <p>Fixes</p>
-+       <ul>
-+       <li>Fixed a crash during the changing voice of chord with tied grace note</li>
-+       <li>Fixed a wrong curly bracket scaling when using MuseJazz</li>
-+       <li>Fixed a scaling of tuplet number</li>
-+       <li>Fixed an issue when Staff/Part dialog changes not dirty when activated via double click</li>
-+       <li>Fixed an issue when divider was not removed after undo of deleting a vertical frame</li>
-+       <li>Fixed an issue when triple and quadruple dots was not exported correctly</li>
-+       <li>Fixed an issue when tremolo customizations lost on second save/reload</li>
-+       <li>Fixed the various issues with handling the title frame on MusicXML import</li>
-+       <li>Fixed an issue when decrescendo doesn't work on tied notes with subchannels</li>
-+       <li>Fixed an issue when changing portaudio preferences does not work</li>
-+       <li>Fixed an issue with loudness of accents</li>
-+       <li>Fixed an issue when changing portaudio preferences does not work</li>
-+       <li>Chord symbol playback settings are now available in Edit Style dialog </li>
-+       <li>Fixed an issue when changes to Measure properties are not propagated between score and parts </li>
-+       <li>Fixed an issue when Ctrl+Delete command was not alowed from note input mode </li>
-+       <li>Added preferences to disable chord symbol playback when opening old scores, or creating new ones </li>
-+       <li>Fixed an issue with entering notes above/below staff</li>
-+       <li>Fixed an issue with assertion failure adding image to vertical frame</li>
-+       <li>Fixed issues with voice and chords with drum input</li>
-+       <li>Fixed the crashes with using the hbox within vbox</li>
-+       <li>Fixed a crash when deleting all measures</li>
-+       <li>Added the guitar "Solo" templates with default guitar sound</li>
-+       <li>Fix invisible elements not getting displayed after turning "Show invisible" on</li>
-+       <li>Fixed an issue when 1-line staves show unexpected vertical offset</li>
-+       <li>Fixed an issue with bad selection and corruption on delete</li>
-+       <li>Fixed an issue with changing Common time to Cut time in parts shuts down the program</li>
-+       <li>Fixed a crash on playback of score with MM rest at the end</li>
-+       <li>Updated extra navigation shortcuts to handle MMRests appropriately</li>
-+       <li>Updated offsets of Gonville's top &amp; bottom bracket glyphs</li>
-+       <li>"add clef" shortcuts are now allowed to also work in normal mode</li>
-+       <li>Fixed an issue when clicking footer text corrupts parts</li>
-+       <li>Fixed an issue when continuous view stops repeats from working in playback</li>
-+       <li>Fixed an issue when drag and drop a breath &amp; pause or rest symbol from the score to a custom palette crashes the program</li>
-+       <li>Fixed a crash on flipping beam across system break</li>
-+       <li>Fixed an issue when status bar does not show concert pitch of octave transposing instruments</li>
-+       <li>Fixed an issue when ambitus not correctly calculated for (octave) transposing instruments</li>
-+       <li>Fixed the crashes when pasting fret diagram without chord symbol in score with parts</li>
-+       <li>Fixed an issue when instrument change data not properly saved in linked staves</li>
-+       <li>Fixed an issue when pasting a measure with "above" breaths/pauses flips them to "below"</li>
-+       <li>Now it possible to flip breaths/pauses using X</li>
-+       <li>Fixed an issue when alpha (transparency) not showing on several symbols and Elements</li>
-+       <li>Fixed an issue when Create Time Signature dialog doesn't need to add special text whenever the internal value of nominator or denominator is changed</li>
-+       <li>Added a fractional Time Signatures Support</li>
-+       <li>Fixed an issue when unintended loss of denominator in Time Signatures</li>
-+       <li>Fixed an issue with export to WAV, OGG, FLAC files with the path name that contains non-ASCII characters</li>
-+       <li>Fixed the crashes after update due to qmlcache </li>
-+       <li>Adjusted a size of settings field for multimeasure rests</li>
-+       <li>Fixed an issue when changing language settings changes to Basic workspace</li>
-+       <li>Fixed an issue when file operations cause crash after changing translations in preferences</li>
-+       <li>Fixed an issue when In triplet in last Half Note of 6/4, changing last Quarter Note in triplet to Eight causes corruption</li>
-+       <li>Fixed an issue when Start center crashes MuseScore if there is no Internet connection</li>
-+       <li>Fixed a crash on DPI change in preferences</li>
-+       <li>Fixed an issue when inserting a new measure within a melisma causes a crash</li>
-+       <li>Fixed an issue when pairs of acciaccaturas show two slashes instead of one</li>
-+       </ul>
-+      </description>
-+    </release>
-+    <release date="2020-08-05" version="3.5.0">
-+      <url>https://musescore.org/en/node/308610</url>
-+      <description>
-+      <p>New features</p>
-+      <ul>
-+      <li>Option available in Preferences for playback of chord symbols</li>
-+      <li>Mid-staff instrument changes now do almost everything automatically (see [below](#instrument-changes))</li>
-+      <li>Support for Orca (Linux) screenreader</li>
-+      <li>Hairpins, voltas, and other lines now adapt anchor points when dragged</li>
-+      <li>Much more functional piano roll editor (see [below](#pre))</li>
-+      <li>Splash screen displays progress messages while loading MuseScore</li>
-+      <li>Diatonic pitch up/down (keep degree alterations) shortcuts</li>
-+      <li>Select Similar Elements: Same Beat</li>
-+      <li>#293113: New Score Wizard automatically numbers instruments</li>
-+      <li>#18897: Property for beam style of tremolo (all strokes attached to stem)</li>
-+      <li>#296075: Style for hiding brackets which span to a single staff when empty staves are hidden</li>
-+      <li>#203026: Properties and styles for measure number positioning, including centered and below staff</li>
-+      <li>#65241: Property and style for position of multimeasure rest numbers</li>
-+      <li>#299644: Property for fretboard diagram rotation</li>
-+      </ul>
-+
-+       <p>Improvements</p>
-+       <ul>
-+       <li>#16077: Double-click a header, footer, or instrument name to access the dialog for editing it</li>
-+       <li>#27371: Score tabs can now be closed using mouse middle button</li>
-+       <li>Improved layout of two-note and single-note tremolos, with and without stem</li>
-+       <li>#93376: Smooth scrolling during playback in Continuous view</li>
-+       <li>Various improvements to simplify searching and loading backup files</li>
-+       <li>#303617: Metric modulation for dotted eighth to quarter</li>
-+       <li>Automatic collision avoidance between rests and notes/rests in other voices</li>
-+       <li>Staff property to automatically merge rests between voices</li>
-+       <li>Allow selection of multiple similar items with shift+click</li>
-+       <li>Allow &quot;repeating a note&quot; by clicking a notehead then pressing &quot;R&quot; in normal mode</li>
-+       <li>Changes made in Preferences are applied significantly faster</li>
-+       <li>Style options to align chord symbols within systems</li>
-+       <li>More zoom controls</li>
-+       <li>Additional plugin capabilities</li>
-+       <li>Altered keyboard and mouse zoom precision and consistency</li>
-+       <li>Improved performance of applying preferences</li>
-+       <li>Chords playback is on by default (untick the "play" property to disable it)</li>
-+       <li>Adding notes to a tuplet now adds them with respect to the tuplet's space</li>
-+       <li>MuseScore 3 is now available as a Windows PortableApp</li>
-+       <li>Altered Shift+L/R for leading space while in edit mode upon notehead</li>
-+       <li>All symbols are now available for the plugins</li>
-+       </ul>
-+
-+       <p>Fixes</p>
-+       <ul>
-+       <li>JACK audio/MIDI worked incorrectly on some platforms</li>
-+       <li>#148311: Loop playback skipped final rests in the last measure</li>
-+       <li>MIDI note-off events were not sent in some cases</li>
-+       <li>Undoing slur addition to a range only removed one slur</li>
-+       <li>Canceling a selection worked incorrectly in some cases </li>
-+       <li>macOS package was not notarized in Apple</li>
-+       <li>Various fixes for the text editing process</li>
-+       <li>Fixed an issue when hiding notes or rests in a voice > 1 causes stems/beams to flip in a bad and unexpected way</li>
-+       <li>Fixed an issue when two grace notes disabling vertical chord alignment (Maximum Shift Above)</li>
-+       <li>Fixed an issue when "maximum shift above" leading to layout weirdness if measure has rhythm slashes and rests</li>
-+       <li>Fixed an issue with inactive "Realize chord symbols" command</li>
-+       <li>Fixed an issue when key signature appears in multiple places on the single staff</li>
-+       <li>Fixed an issue with missing grid of measures in the "timeline" view</li>
-+       <li>Fixed an issue with appearing of empty dialog during the "Save Online"</li>
-+       <li>Fixed an crash during the drag &amp; drop of volta in continuous view</li>
-+       <li>Brackets were displaced in Continuous View</li>
-+       <li>Nested tuplets in linked staves led to corruption</li>
-+       <li>Octave selection was inconsistent in note input mode</li>
-+       <li>Voices worked incorrectly in the parts dialog in some cases</li>
-+       <li>Misclicking when attempting to create a range selection caused the current selection to be lost</li>
-+       <li>On-screen rendering of synthetically emboldened fonts was broken in some cases</li>
-+       <li>Smooth scrolling worked wrong in Continuous view when dealing with repeats</li>
-+       <li>Saving Online a yet unsaved or uncompressed (mscx) file didn't work</li>
-+       <li>Fixed zoom-box 100% selection bug</li>
-+       <li>Fixed a bug with ignoring of blank lines at top of text elements</li>
-+       <li>Fixed an issue when cut/paste, drag/drop in Piano Roll Editor does not preserve NoteEvent values</li>
-+       <li>Fixed a playback of chord symbols attached to fret diagrams</li>
-+       <li>Fixed a note entry suggested position with no selection and last selected note in voice > 1</li>
-+       <li>Fixed a display of the bold and underlined texts</li>
-+       <li>Fixed the "Save Online" on AppImages</li>
-+       </ul>
-+      </description>
-+    </release>
-+    <release date="2020-02-07" version="3.4.2">
-+      <url>https://musescore.org/en/3.4.2</url>
-+      <description>
-+        <p>Fixes:</p>
-+        <ul>
-+          <li>Telemetry dialog was not accessible for visually impaired people</li>
-+          <li>Drum input palette worked incorrectly due to the changes involving single click behaviour</li>
-+          <li>MuseScore crashed when pressing numbers/letters in a different voice when inputting tabs</li>
-+          <li>Hidden pedal items were no longer displayed</li>
-+          <li>"L" letter could not be typed when entering text</li>
-+        </ul>
-+      </description>
-+    </release>
-+    <release date="2020-01-25" version="3.4.1">
-+      <url>https://musescore.org/en/3.4.1</url>
-+      <description>
-+        <p>Fixes:</p>
-+        <ul>
-+          <li>MuseScore crashed after closing a menu bar pop-up window if no score is opened</li>
-+          <li>Audio glitches on note input and playback happened on macOS and other platforms</li>
-+          <li>Parts corruption happened on timewise delete of individual beats</li>
-+          <li>Crash happened when undoing "Beam middle" setting on a single note</li>
-+          <li>Pedal lines alignment applied to the whole system, not individual staff</li>
-+        </ul>
-+      </description>
-+    </release>
-+    <release date="2020-01-23" version="3.4">
-+      <url>https://musescore.org/en/3.4</url>
-+      <description>
-+        <p>New:</p>
-+        <ul>
-+          <li>Apply palette elements with a single click if there is a selection in the score</li>
-+          <li>Allow dragging notes horizontally</li>
-+          <li>Slurs, hairpins and other elements can be edited after a single click</li>
-+          <li>Add middle adjustment handle for beams, for moving whole beam horizontally</li>
-+          <li>Add command-line option for transposing scores</li>
-+        </ul>
-+        <p>Improvements:</p>
-+        <ul>
-+          <li>Double click is not needed to reach edit mode anymore</li>
-+          <li>Introduce bend properties in the Inspector</li>
-+          <li>Allow access to several properties window in the Inspector</li>
-+          <li>Name of the newly created custom palette can be specified</li>
-+          <li>Accessibility: improve speech for elements with spanners</li>
-+          <li>Embed Tremolo Bar editor to the inspector</li>
-+        </ul>
-+        <p>Fixes:</p>
-+        <ul>
-+          <li>"Don't play trill" option silenced the note playback</li>
-+          <li>Slurs on small staves were displaced in some cases</li>
-+          <li>Barline handles were drawn incorrectly after dragging one</li>
-+          <li>Strings in the Part dialogue were ambiguous</li>
-+          <li>Y Offset value of fretboards didn't restore after undoing the values being changed from Edit Mode</li>
-+          <li>Replacing a note with an accidental left the accidental on the new note</li>
-+          <li>Adding Intervals (above/below) didn't take into consideration the accidental toggle state</li>
-+          <li>Multiple chord symbols attached to same note didn't copy as part of the range</li>
-+          <li>Strings in fret diagrams without "X" or "O" displayed as "?" on Linux</li>
-+          <li>MuseScore crashed when changing a triplet's rest's duration</li>
-+          <li>Images attached to rests weren't imported from MuseScore 2</li>
-+          <li>Tremolo Bar dialog had multiple UX issues</li>
-+        </ul>
-+      </description>
-+    </release>
-     <release date="2019-12-04" version="3.3.4">
-        <url>https://musescore.org/en/3.3.4</url>
-        <description>
+@@ -7,13 +7,12 @@
+ 
+         After editing, run either of these commands to check for errors in this file:
+             $  appstreamcli validate [filename]
+-            $  appstream-util validate-relax [filename]
++            $  appstream-util validate [filename]
+     -->
+     <id>org.musescore.MuseScore@MSCORE_INSTALL_SUFFIX@</id>
+     <metadata_license>CC0-1.0</metadata_license><!-- License of this file. See <project_license> for MuseScore license. -->
+     <name>MuseScore</name>
+     <summary>Create, play and print beautiful sheet music</summary>
+-    <icon type="stock">mscore@MSCORE_INSTALL_SUFFIX@</icon>
+     <description>
+         <p>MuseScore is cross-platform, multi-lingual, open source music notation software. It features an easy to use WYSIWYG editor with audio score playback for results that look and sound beautiful. It supports unlimited staves with up to four voices each, dynamics, articulations, lyrics, chords, lead sheet notation, import/export of MIDI and MusicXML, export to PDF and WAV, plus online score sharing.</p>
+         <p>MuseScore can upload scores directly to the score sharing site musescore.com. Program support is provided on musescore.org.</p>
+@@ -115,6 +114,8 @@
+     </kudos>
+     <!-- Only <releases> below this point please! -->
+     <releases>
++        <release date="2022-10-24" version="4.0.0_beta" />
++        <release date="2022-08-09" version="4.0.0_alpha_2" />
+         <release date="2021-02-08" version="3.6.2">
+             <url>https://musescore.org/en/3.6.2</url>
+         </release>
+@@ -130,9 +129,6 @@
+         <release date="2020-10-09" version="3.5.1">
+             <url>https://musescore.org/en/3.5.1</url>
+         </release>
+-        <release date="2020-10-09" version="3.5.1">
+-            <url>https://musescore.org/en/3.5.1</url>
+-        </release>
+         <release date="2020-08-07" version="3.5">
+             <url>https://musescore.org/en/3.5</url>
+         </release>

--- a/patches/musescore-fixes.patch
+++ b/patches/musescore-fixes.patch
@@ -10,20 +10,6 @@ index 6713e3aeef..58cc8cee14 100644
  
  IF(BUILD_JACK)
       IF(MINGW OR MSVC)
-diff --git a/src/framework/global/types/string.cpp b/src/framework/global/types/string.cpp
-index e255f17a21..06b640241d 100644
---- a/src/framework/global/types/string.cpp
-+++ b/src/framework/global/types/string.cpp
-@@ -477,6 +477,9 @@ String String::fromQString(const QString& str)
- 
- QString String::toQString() const
- {
-+    if (empty()) {
-+        return QString();
-+    }
-     const char16_t* u = &constStr().front();
-     static_assert(sizeof(QChar) == sizeof(char16_t));
-     return QString(reinterpret_cast<const QChar*>(u), static_cast<int>(size()));
 diff --git a/src/framework/vst/CMakeLists.txt b/src/framework/vst/CMakeLists.txt
 index 368d686b53..7c0201a7dd 100644
 --- a/src/framework/vst/CMakeLists.txt


### PR DESCRIPTION
- Update runtime to 22.08
- Update patches
- Remove crashpad.