### PR TITLE
Fix Musescore not Starting Issue on Wayland Systems

### DIFF
--- a/org.musescore.MuseScore.yaml
+++ b/org.musescore.MuseScore.yaml
@@ -29,6 +29,7 @@ finish-args:
   - --filesystem=home
   # Allow other instances to see lockfiles
   - --env=TMPDIR=/var/tmp
+  - --env=QT_QPA_PLATFORM=xcb
   - --filesystem=xdg-run/pipewire-0
   - --system-talk-name=org.freedesktop.UPower
 


### PR DESCRIPTION
On a wayland machine currently Musescore does not start as it does not have the permission to use wayland.

Since wayland is broken the wayland permission was removed. Add the environment variable to start the application in X-Wayland mode instead of crashing for systems that run on Wayland.